### PR TITLE
fix: remove duckdb from peerDependencies to prevent client-side bundling issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coji/kysely-duckdb-wasm",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "kysely dialect for duckdb wasm",
   "exports": {
     "require": "./dist/index.cjs",
@@ -36,7 +36,6 @@
   "peerDependencies": {
     "@duckdb/duckdb-wasm": "*",
     "apache-arrow": "*",
-    "duckdb": "^1",
     "kysely": "^0.28"
   },
   "prettier": {


### PR DESCRIPTION
## Summary
- Removed `duckdb` package from peerDependencies
- Bumped version to 0.1.5
- This prevents module errors when bundling for client-side use

## Problem
The `duckdb` package is a native Node.js module that cannot be bundled for browser environments. When it was listed as a peer dependency, users who tried to bundle their applications with tools like webpack or vite would encounter module resolution errors.

## Solution
Since this library is specifically designed for DuckDB WebAssembly (`@duckdb/duckdb-wasm`), the native `duckdb` package is not needed as a peer dependency. Removing it allows the library to be properly bundled for client-side applications without errors.

## Test plan
- [x] Verify the library builds successfully
- [x] Ensure existing tests pass
- [ ] Test in a client-side bundled application to confirm no module errors

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package version to 0.1.5.
  * Removed the peer dependency requirement for "duckdb".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->